### PR TITLE
Adds warning rules for curly and brace-style; adds versioning info

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,10 @@ And here is the `.eslintrc` file you'll need:
 ```
 
 ## Changelog
+New major versions will be used whenever a new rule is added that returns an `error` on failure. This is to avoid breaking projects using this configuration as they do normal package updates. If a new rule is added that is simply set to `warn`, minor versions may be used since this should not break build, but only create warning messages for you to resolve or override with rules in your project configuration.
 
-2.0.2: packaging issue, no changes.
-
-2.0.1: use `import/no-extraneous-dependencies` to detect `require` calls that are not backed by a real dependency of this project or module.
-
-2.0.0: initial release.
+- 3.1.0: Adds a warning for the `curly` and `brace-style` rules to avoid single line blocks. Adds the changelog versioning guidelines.
+- 3.0.0: Adds a warning for the `no-var` rule.
+- 2.0.2: packaging issue, no changes.
+- 2.0.1: use `import/no-extraneous-dependencies` to detect `require` calls that are not backed by a real dependency of this project or module.
+- 2.0.0: initial release.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ And here is the `.eslintrc` file you'll need:
 ## Changelog
 New major versions will be used whenever a new rule is added that returns an `error` on failure. This is to avoid breaking projects using this configuration as they do normal package updates. If a new rule is added that is simply set to `warn`, minor versions may be used since this should not break build, but only create warning messages for you to resolve or override with rules in your project configuration.
 
-- 3.1.0: Adds a warning for the `curly` and `brace-style` rules to avoid single line blocks. Adds the changelog versioning guidelines.
+- 3.1.0: Adds a warning for the `curly` and `brace-style` rules to avoid single line blocks. Also `object-curly-newline` and `object-property-newline` rules to have similar treatment for objects. Adds the changelog versioning guidelines.
 - 3.0.0: Adds a warning for the `no-var` rule.
 - 2.0.2: packaging issue, no changes.
 - 2.0.1: use `import/no-extraneous-dependencies` to detect `require` calls that are not backed by a real dependency of this project or module.

--- a/index.js
+++ b/index.js
@@ -3,6 +3,39 @@ module.exports = {
   "rules": {
     "brace-style": ["warn", "1tbs"],
     "curly": ["warn", "all"],
+    'object-curly-newline': ['warn', {
+      // Object expressions can have one property on a single line.
+      // e.g., `const foo = { bar: 1 };`.
+      'ObjectExpression': {
+        'minProperties': 2,
+        'consistent': true,
+        'multiline': true
+      },
+      // Object destructuring can have two properties on a single line.
+      // e.g., `const { foo, bar }= baz;`.
+      'ObjectPattern': {
+        'minProperties': 3,
+        'consistent': true,
+        'multiline': true
+      },
+      // Import declarations can have two properties on a single line.
+      // e.g., `import { foo, bar } from 'baz';`.
+      'ImportDeclaration': {
+        'minProperties': 3,
+        'consistent': true,
+        'multiline': true
+      },
+      // Export declarations can have two properties on a single line.
+      // e.g., `export { foo, bar };`.
+      'ExportDeclaration': {
+        'multiline': true,
+        'consistent': true,
+        'minProperties': 3
+      }
+    }],
+    'object-property-newline': [
+      'warn', { 'allowAllPropertiesOnSameLine': false }
+    ],
     'semi': [ 'error', 'always' ],
     'no-unused-vars': ['error', { 'varsIgnorePattern': 'apos', 'args': 'none', 'ignoreRestSiblings': true }],
     "space-before-function-paren": 0,

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 module.exports = {
   'extends': 'standard',
   "rules": {
+    "brace-style": ["warn", "1tbs"],
+    "curly": ["warn", "all"],
     'semi': [ 'error', 'always' ],
     'no-unused-vars': ['error', { 'varsIgnorePattern': 'apos', 'args': 'none', 'ignoreRestSiblings': true }],
     "space-before-function-paren": 0,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-apostrophe",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "eslint configuration for apostrophe and related core modules",
   "main": "index.js",
   "scripts": {
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "git+https://github.com/apostrophecms/eslint-config-apostrophe.git"
   },
-  "author": "P'unk Avenue LLC",
+  "author": "Apostrophe Technologies, Inc.",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/apostrophecms/eslint-config-apostrophe/issues"


### PR DESCRIPTION
This is to avoid one line blocks, e.g., `if (foo) return;`.

The `object-curly-newline` and `object-property-newline` rules require more discussion. These provide leeway for at least a single property within objects on a single line, but depending on the case require breaking the lines with more than that.