### PR TITLE
PRO-2751: semver dependency on a major release of eslint-config-standard that still supports eslint 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 3.4.2 2022-04-20
+
+Use semver range to pin to a major version of eslint-config-standard that supports eslint 7.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-apostrophe",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "eslint configuration for apostrophe and related core modules",
   "main": "index.js",
   "scripts": {
@@ -23,7 +23,7 @@
     "eslint": "^7.1.0"
   },
   "dependencies": {
-    "eslint-config-standard": ">=14.1.1",
+    "eslint-config-standard": "^16.0.3",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.2.1",


### PR DESCRIPTION
…
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

An open-ended semver range was used to import the latest eslint-config-standard, which eventually broke our world when it became incompatible with eslint 7 and had other issues.

Solved by setting an appropriate major version of eslint-config-standard for now.

## What are the specific steps to test this change?

When the apostrophe module is npm linked with this branch, `npm run lint` passes for the apostrophe module. If you see it pass without this update, try using node 14, deleting `node_modules` and removing `package-lock.json` before npm installing.

## What kind of change does this PR introduce?
*(Check at least one)*

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
