### PR TITLE
Adds max len

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
+## UNRELEASED
+
+### Adds
+
+- Adds max-len rule
+
 ## 4.1.0 - 2023-08-03
 
-### Changed
+### Adds
 
 - Use latest eslint-config-standard
 
@@ -11,11 +17,11 @@
 - Upgraded dependencies
 - Swapped eslint-plugin-node for eslint-plugin-n which is what standard now uses
 
-### Added
+### Adds
 
 - Added missing rules no-var, object-shorthand, array-callback-return, default-case-last, multiline-ternary, no-useless-backreference, no-empty, no-import-assign, no-loss-of-precision, no-unreachable-loop, prefer-regex-literals, n/handle-callback-err, n/no-callback-literal, n/no-deprecated-api, n/no-exports-assign, n/no-new-require, n/no-path-concat, n/process-exit-as-throw
 
-### Fixed
+### Fixes
 
 - Fixed `compare` check which was returning some false positives
 

--- a/eslintrc.json
+++ b/eslintrc.json
@@ -159,7 +159,11 @@
     ],
     "max-len": [
       "error",
-      90
+      {
+        "code": 90,
+        "ignoreRegExpLiterals": true,
+        "ignoreUrls": true
+      }
     ],
     "multiline-ternary": [
       "error",

--- a/eslintrc.json
+++ b/eslintrc.json
@@ -157,6 +157,10 @@
         "exceptAfterSingleLine": true
       }
     ],
+    "max-len": [
+      "error",
+      90
+    ],
     "multiline-ternary": [
       "error",
       "always-multiline"

--- a/lib/checkUpdates.js
+++ b/lib/checkUpdates.js
@@ -9,20 +9,21 @@ const getInstalledVersion = ({ name, version }) => {
 
 const getVersionNumber = string => {
   const semver = /[~^><=x]/gi;
-  return string.replace(semver, '');
+  return string.replace(semver, '').trim();
 };
 
 const checkUpdates = () => {
   console.log(`\neslint-config-apostrophe:\n
     Checking for eslint-config updates...`);
 
-  const { dependencies } = pkg;
+  const { peerDependencies } = pkg;
 
   const availableUpdates = {};
 
-  Object.keys(dependencies).forEach(dependency => {
+  Object.keys(peerDependencies).forEach(dependency => {
     const name = dependency;
-    const version = getVersionNumber(dependencies[dependency]);
+    const version = getVersionNumber(peerDependencies[dependency]);
+    console.log('version', version)
 
     const updateAvailable = getInstalledVersion({
       name,

--- a/package.json
+++ b/package.json
@@ -23,13 +23,12 @@
     "url": "https://github.com/apostrophecms/eslint-config-apostrophe/issues"
   },
   "homepage": "https://github.com/apostrophecms/eslint-config-apostrophe#readme",
-  "peerDependencies": {
+  "dependencies": {
     "eslint": ">= 8.39.0",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-n": "^16.0.0",
-    "eslint-plugin-promise": "^6.1.1"
-  },
-  "dependencies": {
+    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-promise": "^6.1.1",
     "eslint-config-standard": "^17.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,12 +24,13 @@
   },
   "homepage": "https://github.com/apostrophecms/eslint-config-apostrophe#readme",
   "dependencies": {
-    "eslint": ">= 8.39.0",
-    "eslint-plugin-import": "^2.27.5",
-    "eslint-plugin-n": "^16.0.0",
+    "eslint": "^8.53.0",
+    "eslint-config-standard": "^17.1.0",
+    "eslint-plugin-import": "^2.29.0",
+    "eslint-plugin-n": "^16.2.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^6.1.1",
-    "eslint-config-standard": "^17.1.0"
+    "eslint-plugin-standard": "^4.0.1"
   },
   "devDependencies": {
     "mocha": "^10.2.0"

--- a/package.json
+++ b/package.json
@@ -23,14 +23,14 @@
     "url": "https://github.com/apostrophecms/eslint-config-apostrophe/issues"
   },
   "homepage": "https://github.com/apostrophecms/eslint-config-apostrophe#readme",
-  "dependencies": {
-    "eslint": "^8.53.0",
+  "peerDependencies": {
+    "eslint": ">= 8.53.0",
     "eslint-config-standard": "^17.1.0",
     "eslint-plugin-import": "^2.29.0",
     "eslint-plugin-n": "^16.2.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^6.1.1",
-    "eslint-plugin-standard": "^4.0.1"
+    "eslint-plugin-standard": "^4.1.0"
   },
   "devDependencies": {
     "mocha": "^10.2.0"


### PR DESCRIPTION
## Summary

Adds max-len.
Move all dependencies installed in projects here, would be nice to not having to install 10 eslint related dependencies when we create a new project.
Fixes `checkUpdates` script to parse `peerDependencies`.
